### PR TITLE
feat: implement delete command and update help

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -24,6 +24,7 @@ Commands:
   edit <id> "new name" Edit a task description
   clear                Delete all tasks
   help                 Show this help message
+  delete <id>          Remove a specific task
 
 
 Examples:
@@ -128,6 +129,25 @@ func main() {
 			return
 		}
 		fmt.Println("Tasks marked as done")
+	
+	case "delete":
+		if len(os.Args) < 3 {
+            fmt.Println("Usage: task delete <id>")
+            return
+        }
+
+        taskNum, err := strconv.Atoi(os.Args[2])
+        if err != nil {
+            fmt.Println("❌ Error: Invalid task number")
+            return
+        }
+
+        if err := task.DeleteTask(taskNum); err != nil {
+            fmt.Printf("❌ Error: %v\n", err)
+            return
+        }
+
+        fmt.Printf("✅ Task #%d deleted successfully\n", taskNum)
 
 	default:
 		fmt.Println("Unknown command:", os.Args[1])

--- a/internal/task/delete.go
+++ b/internal/task/delete.go
@@ -1,0 +1,43 @@
+package task
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+
+func DeleteTask(taskNumber int) error {
+	path, err := dataFilePath()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if taskNumber < 1 || taskNumber > len(lines) {
+		return fmt.Errorf("invalid task number: %d (valid range: 1-%d)", taskNumber, len(lines))
+	}
+
+	lines = append(lines[:taskNumber-1], lines[taskNumber:]...)
+	
+	return os.WriteFile(
+		path,
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		0644,
+	)
+}


### PR DESCRIPTION
I have implemented the functionality to delete a specific task by its ID to resolve issue #5.

To achieve this, I created the file internal/task/delete.go with the removal logic and updated cmd/task/main.go to recognize the new command and display instructions in the help menu.

Example usage: task delete 1

Closes #5

## Summary by Sourcery

New Features:
- Introduce a delete subcommand to remove a specific task by its ID from the task list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “delete” command to the CLI to remove a task by its number.
  * Input is validated with clear error messages and usage guidance for missing or invalid task IDs.
  * Successful deletions show a confirmation message.
  * Help text updated to document the new command.
  * Existing commands remain unchanged for a seamless upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->