### PR TITLE
fix duplicate doneAll function fixes #10

### DIFF
--- a/internal/task/done.go
+++ b/internal/task/done.go
@@ -73,50 +73,6 @@ func Done(idStr string) error {
 }
 
 func DoneAll() error {
-	path, err := dataFilePath()
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	var tasks []string
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Split(line, "|")
-		if len(parts) >= 1 {
-			parts[1] = "done"
-			line = strings.Join(parts, "|")
-		}
-		tasks = append(tasks, line)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-
-	f, err = os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	for _, task := range tasks {
-		_, err = f.WriteString(task + "\n")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func DoneAll() error {
 	// Get absolute path to ~/.task/tasks.txt
 	path, err := dataFilePath()
 	if err != nil {


### PR DESCRIPTION
Deletes the extra ```DoneAll``` definition and retains the correct version to prevent compile-time errors.

Closes: #10, 

<img width="1843" height="942" alt="Screenshot 2026-02-03 215937" src="https://github.com/user-attachments/assets/28436059-71a8-469a-bfff-8cb01407051b" />

## Summary by Sourcery

Bug Fixes:
- Eliminate the redundant DoneAll function definition so only the correct implementation remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mark all tasks as done feature to handle edge cases and malformed task entries gracefully, preventing potential crashes.
  * Streamlined and optimized the task update process for better performance and reliability when working with multiple tasks or large task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->