### PR TITLE
[bug]: added lock to remove race conditions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Built binaries
-task
+/task
 task-mac
 task-mac-intel
 task-linux

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -47,6 +47,14 @@ func main() {
 		return
 	}
 
+	unlock, err := task.AcquireLock()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	defer unlock()
+
 	switch os.Args[1] {
 
 	case "add":

--- a/internal/task/lock.go
+++ b/internal/task/lock.go
@@ -1,0 +1,42 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+
+func AcquireLock() (func(), error) {
+	path, err := dataFilePath()
+	if err != nil {
+		return nil, err
+	}
+	
+	// Lock file acts as a flag: if it exists, the DB is busy.
+	lockPath := filepath.Join(filepath.Dir(path), "tasks.lock")
+
+	for i := 0; i < 10; i++ { // Try 10 times (1 second total)
+		
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL, 0644)
+		if err == nil {
+			
+			f.Close()
+			
+			return func() {
+				os.Remove(lockPath)
+			}, nil
+		}
+
+		
+		if !os.IsExist(err) {
+			return nil, err
+		}
+
+		
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("could not acquire lock: another task process is running")
+}


### PR DESCRIPTION
closes #19 , 

This PR introduces a file locking mechanism to ensure data integrity when multiple instances of the task CLI are run concurrently . It also fixes a .gitignore issue that was incorrectly masking source files.

Added lock.go: Implements a cross-platform lock file mechanism (tasks.lock) alongside the data file. It attempts to acquire a lock for up to 1 second before timing out.

Updated main.go: Wraps the command execution in AcquireLock() and ensures the lock is released via defer.
Updated .gitignore: Changed task to /task to ensure the binary is ignored without hiding the task/ source directory or new files like lock.go.

## Summary by Sourcery

Add a file-based locking mechanism to prevent concurrent task CLI instances from corrupting data and adjust ignore rules for the compiled binary.

Bug Fixes:
- Prevent race conditions and data corruption by serializing task operations with a lock file.

Enhancements:
- Introduce a reusable lock acquisition helper in the task package that manages lock lifecycle around command execution.

Build:
- Update .gitignore to ignore only the compiled task binary without hiding the source directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added file locking mechanism to prevent conflicts when accessing tasks concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->